### PR TITLE
Change imagePullPolicy to Always

### DIFF
--- a/shoppingcartapp/shoppingcartapp.yaml
+++ b/shoppingcartapp/shoppingcartapp.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: shoppingcartapp
           image: "shoppingcartapp:0.1"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true


### PR DESCRIPTION
For some reason, cluster wasn't boot-strapping in multinode environments. Changing the imagePolicy to always helped